### PR TITLE
expose the camera

### DIFF
--- a/DisplayInterface/QOSGWidget.h
+++ b/DisplayInterface/QOSGWidget.h
@@ -73,6 +73,9 @@ class QOSGWidget : public QGLWidget
     /// @brief   Get the root osg node
     osg::ref_ptr<osg::Group> getRootGroup() const { return m_pRoot; };
 
+    /// @brief   Provide access to the underlying camera
+    osg::ref_ptr<osg::Camera> getCamera() const { return m_pOsgViewer->getCamera(); };
+
     /// @brief   Allow to set the root group
     inline void setRootGroup(osg::ref_ptr<osg::Group> group)
     {


### PR DESCRIPTION
Need to have access to the camera matrix (and other stuff) to give users the ability to project rays into the scene, or do modifications to the camera - seems like a thing we would want to enable.