### PR TITLE
Added Images

### DIFF
--- a/DisplayObjects/Images.cpp
+++ b/DisplayObjects/Images.cpp
@@ -1,0 +1,94 @@
+/////////////////////////////////////////////////////////////////
+/// @file      Images.cpp
+/// @author    Chris L Baker (clb) <chris@chimail.net>
+/// @date      2015.02.10
+/// @brief     Display an images in 3D
+///
+/// @attention Copyright (C) 2015
+/// @attention All rights reserved
+/////////////////////////////////////////////////////////////////
+
+#include "Images.h"
+
+#include <osg/Geometry>
+#include <osg/Texture2D>
+#include <osg/Geode>
+#include <osg/TexEnv>
+
+namespace d3
+{
+
+/////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////
+osg::ref_ptr<osg::Node> get(const ImageVec_t& images)
+{
+    osg::ref_ptr<osg::Group> rv( new osg::Group() );
+
+    for ( const auto& image : images )
+    {
+        // compute the new image width and height
+        double ww( static_cast<double>(image.image->s()) * image.scale/image.focalLengthX_pix );
+        double hh( static_cast<double>(image.image->t()) * image.scale/image.focalLengthY_pix );
+
+        // here we create a quad that will be texture mapped with the image
+        osg::ref_ptr<osg::Vec3Array> quad( new osg::Vec3Array() );
+        quad->push_back( osg::Vec3( -ww/2.0, -hh/2.0, image.scale ) );
+        quad->push_back( osg::Vec3(  ww/2.0, -hh/2.0, image.scale ) );
+        quad->push_back( osg::Vec3(  ww/2.0,  hh/2.0, image.scale ) );
+        quad->push_back( osg::Vec3( -ww/2.0,  hh/2.0, image.scale ) );
+        osg::ref_ptr<osg::Geometry> geo( new osg::Geometry() );
+        geo->setVertexArray( quad );
+
+        // here we create a drawing elelment to draw on
+        osg::ref_ptr<osg::DrawElementsUInt>
+            primitiveSet( new osg::DrawElementsUInt(osg::PrimitiveSet::QUADS, 0) );
+        primitiveSet->push_back( 0 );
+        primitiveSet->push_back( 1 );
+        primitiveSet->push_back( 2 );
+        primitiveSet->push_back( 3 );
+        geo->addPrimitiveSet( primitiveSet );
+
+        // the texture mappings
+        osg::ref_ptr<osg::Vec2Array> texCoords( new osg::Vec2Array(4) );
+        (*texCoords)[0].set( 0.0f, 0.0f );
+        (*texCoords)[1].set( 1.0f, 0.0f );
+        (*texCoords)[2].set( 1.0f, 1.0f );
+        (*texCoords)[3].set( 0.0f, 1.0f );
+        geo->setTexCoordArray( 0, texCoords );
+
+        // now create the goede to hold our created geometry
+        osg::ref_ptr<osg::Geode> geode( new osg::Geode() );
+        geode->addDrawable( geo );
+
+        // create the texture for the image
+        osg::ref_ptr<osg::Texture2D> texture( new osg::Texture2D() );
+        texture->setDataVariance(osg::Object::DYNAMIC);
+        texture->setImage( image.image );
+
+        // put this in decal mode
+        osg::ref_ptr<osg::TexEnv> decalTexEnv( new osg::TexEnv() );
+        decalTexEnv->setMode(osg::TexEnv::DECAL);
+
+        // set the state set, lighting and such, so we actually display the image
+        osg::ref_ptr<osg::StateSet> stateSet( geode->getOrCreateStateSet() );
+        stateSet->setTextureAttributeAndModes(0, texture, osg::StateAttribute::ON);
+        stateSet->setTextureAttribute(0, decalTexEnv);
+        stateSet->setMode( GL_LIGHTING, osg::StateAttribute::OFF );
+        geo->setStateSet(stateSet);
+
+        // turn off any color binding - we want to use the texture
+        geo->setColorBinding(osg::Geometry::BIND_OFF);
+
+        // set our matrix as the provided camera matrix
+        osg::ref_ptr<osg::MatrixTransform> xform(new osg::MatrixTransform());
+        xform->setMatrix(image.cameraPose);
+        xform->addChild(geode);
+
+        // add this image and continue
+        rv->addChild(xform);
+    }
+
+    return rv;
+};
+
+} // namespace d3

--- a/DisplayObjects/Images.h
+++ b/DisplayObjects/Images.h
@@ -1,0 +1,53 @@
+/////////////////////////////////////////////////////////////////
+/// @file      Images.h
+/// @author    Chris L Baker (clb) <chris@chimail.net>
+/// @date      2015.02.10
+/// @brief     Display an images in 3D
+///
+/// @attention Copyright (C) 2015
+/// @attention All rights reserved
+/////////////////////////////////////////////////////////////////
+
+#ifndef  _DDD__DISPLAY_OBJECTS__IMAGE_H_
+#define  _DDD__DISPLAY_OBJECTS__IMAGE_H_
+
+#include <osg/MatrixTransform>
+#include <osg/Image>
+
+namespace d3
+{
+
+/// @brief   Define a simple image display - in 3D, this implies that there will
+///          be a simulated camera viewing this image, so we have a camera pose
+///          as part of it
+///
+/// The image type supported are really just
+struct Image
+{
+    /// Store the camera pose
+    osg::Matrix cameraPose;
+
+    /// Store the image to display
+    osg::ref_ptr<osg::Image> image;
+
+    /// Store some camera parameters indicating how to display the image
+    double focalLengthX_pix;
+    double focalLengthY_pix;
+    double scale;
+};
+
+/// The standard "lots of these things"
+typedef std::vector<Image> ImageVec_t;
+
+/// The get for the vector
+osg::ref_ptr<osg::Node> get(const ImageVec_t& images);
+
+/// The get for a single image
+inline osg::ref_ptr<osg::Node> get(const Image& image)
+{
+    return get(ImageVec_t(1, image));
+};
+
+} // namespace d3
+
+#endif   // _DDD__DISPLAY_OBJECTS__IMAGE_H_

--- a/DisplayObjects/SConscript
+++ b/DisplayObjects/SConscript
@@ -20,6 +20,7 @@ env.InstallLib(
             'Grids.cpp',
             'HeadsUpDisplay.cpp',
             'HeightGrid.cpp',
+            'Images.cpp',
             'Lines.cpp',
             'MeshGrid.cpp',
             'Points.cpp',
@@ -28,8 +29,8 @@ env.InstallLib(
             ],
         LIBS = [
             'osg',
-            'osgText',
             'osgManipulator',
+            'osgText',
             ],
         )
     )
@@ -41,6 +42,7 @@ env.InstallHeaders('DDDisplayObjects', [
     'Grids.h',
     'HeadsUpDisplay.h',
     'HeightGrid.h',
+    'Images.h',
     'Lines.h',
     'MeshGrid.h',
     'Points.h',

--- a/Install
+++ b/Install
@@ -3,5 +3,15 @@
 We depend on qt and osg (and on a couple of boost modules for the test apps):
 > sudo apt-get install qt4-dev-tools libopenscenegraph-dev libboost-program-options-dev libboost-filesystem-dev
 
+To build the main test app we also require opencv to load an image (you might want to just get opencv-dev)
+> sudo apt-get install libopencv-core-dev libopencv-highgui-dev
+
 Once those are installed, just run
+> scons -j<numProcessors> libs
+> scons -j<numProcessors> apps
+
+To build the tests, run
+> scons -j<numProcessors> tests
+
+To build it all, run
 > scons -j<numProcessors> all

--- a/app/SConscript
+++ b/app/SConscript
@@ -10,7 +10,7 @@
 
 Import( 'env' )
 
-env.InstallTest(
+env.InstallApp(
     env.Program(
         target = 'dsp',
         source = [

--- a/test/SConscript
+++ b/test/SConscript
@@ -19,6 +19,8 @@ env.InstallTest(
         LIBS = [
             'DDDisplayInterface',
             'DDDisplayObjects',
+            'opencv_core',
+            'opencv_highgui',
             ],
         )
     )

--- a/test/testDeveloperDebugDisplay.cpp
+++ b/test/testDeveloperDebugDisplay.cpp
@@ -60,8 +60,10 @@ int main(int argc, char* argv[])
                            osg::Image::AllocationMode::USE_MALLOC_FREE,
                            1);
 
-        osg::Matrix pp(osg::Matrix::identity());
-        d3::di().add( "image", d3::get(d3::Image{pp, osgImage, 600.0, 600.0, 5.0}) );
+        osg::Matrix pp(osg::Matrix::translate(3,2,1) * osg::Matrix::rotate(1.0, osg::Vec3{1,0.2,0.1}));
+
+        d3::di().add( "image::frame", d3::get(d3::Image{pp, osgImage, 600.0, 600.0, 5.0}) );
+        d3::di().add( "image::camera", d3::get(d3::Triad{pp}) );
     }
 
     d3::di().add( "ground", d3::ground() );

--- a/test/testDeveloperDebugDisplay.cpp
+++ b/test/testDeveloperDebugDisplay.cpp
@@ -23,9 +23,14 @@
 #include <DDDisplayObjects/Spheres.h>
 #include <DDDisplayObjects/HeightGrid.h>
 #include <DDDisplayObjects/HeadsUpDisplay.h>
+#include <DDDisplayObjects/Images.h>
 
 /// Fancier drawing stuff
 #include <osg/MatrixTransform>
+
+/// opencv stuff
+#include <opencv/cv.h>
+#include <opencv/highgui.h>
 
 /// std stuff
 #include <chrono>
@@ -35,6 +40,30 @@
 
 int main(int argc, char* argv[])
 {
+    // the scope here is to make sure that the image given to the display is
+    // held by the display even when this one goes out of scope
+    {
+        cv::Mat img;
+        cv::cvtColor(cv::imread("logo.png"), img, CV_BGR2RGB);
+        int imgSize(img.rows*img.cols*img.channels());
+        uchar* image( (uchar*)malloc(imgSize) );
+        memcpy(image, img.ptr(), imgSize);
+
+        osg::ref_ptr<osg::Image> osgImage(new osg::Image());
+        osgImage->setImage(img.cols,
+                           img.rows,
+                           img.channels(),
+                           GL_RGB,
+                           GL_RGB,
+                           GL_UNSIGNED_BYTE,
+                           image,
+                           osg::Image::AllocationMode::USE_MALLOC_FREE,
+                           1);
+
+        osg::Matrix pp(osg::Matrix::identity());
+        d3::di().add( "image", d3::get(d3::Image{pp, osgImage, 600.0, 600.0, 5.0}) );
+    }
+
     d3::di().add( "ground", d3::ground() );
     d3::di().add( "origin", d3::origin() );
 


### PR DESCRIPTION
This creates a new dependency on the test application for opencv. Instead of adding that dep to the package, it's possible to just build libs and apps (instead of 'all'). building 'tests' will require opencv to read in images from disk. If there's a way to easily split to

sudo apt-get install d3-lib/app/test

or something that would be cool, but really, if it just didn't package the lame test with it, that'd be ok too. I think there's sample code in there already and that's all the test actually provides.